### PR TITLE
Adds optional "ly" to rank in Rank joke.

### DIFF
--- a/jokes/rank.py
+++ b/jokes/rank.py
@@ -36,10 +36,10 @@ class RankJoke(Joke):
             "private",
             "sergeant"
         ]
+        ranks_re = "|".join(ranks)
         self.rank_re = re.compile(
-                r".*(?P<rank>\b(" +\
-                        "|".join(ranks) +\
-                        r"\b))\s+(?P<title>\b\w+\b)", 
+                r".*(?P<rank>\b(" + ranks_re + r"\b))(ly)?" +\
+                        r"\s+(?P<title>\b\w+\b)", 
                 re.IGNORECASE)
 
 


### PR DESCRIPTION
Allows "majorly" and "privately" to be recognized.
Also allows "officerly" and other non-words, but
this is deemed a feature and not a bug.
Closes #24 