### PR TITLE
Chores can now be sniped. Requesting is admin only.

### DIFF
--- a/dad.py
+++ b/dad.py
@@ -767,6 +767,7 @@ class Dad(commands.Cog):
 
 
     @commands.guild_only()
+    @commands.admin()
     @commands.command()
     async def request_chore_for(self, ctx:commands.Context, 
             member:discord.Member):

--- a/jokes/chores.py
+++ b/jokes/chores.py
@@ -130,8 +130,7 @@ class ChoreJoke(Joke):
 
         # Construct predicate to await user response
         def check(reaction, user):
-            return user == member and\
-                    str(reaction.emoji) in solutions
+            return str(reaction.emoji) in solutions
 
         # Await response
         try:
@@ -140,7 +139,7 @@ class ChoreJoke(Joke):
             # Log joke
             LOG.info(f"Chore: Requested joke for "
                 f"\"{member.display_name}\"({member.id})")
-            reaction, user = await bot.bot.wait_for(
+            reaction, completed_user = await bot.bot.wait_for(
                     "reaction_add", timeout=600.0,
                     check=check)
         except asyncio.TimeoutError:
@@ -150,11 +149,20 @@ class ChoreJoke(Joke):
             await chore_msg.add_reaction("👎")
             await bot.add_points_to_member(member, -10)
         else:
-            LOG.info(f"Chore: "
-                f"\"{member.display_name}\"({member.id}) "
-                "succeeded to complete the chore")
-            await chore_msg.add_reaction(reward)
-            await bot.add_points_to_member(member, 5)
+            if member != completed_user:
+                LOG.info(f"Chore: "
+                    f"\"{completed_user.display_name}\"({completed_user.id}) "
+                    " sniped chore from "
+                    f"\"{member.display_name}\"({member.id})")
+                await chore_msg.add_reaction(reward)
+                await bot.add_points_to_member(completed_user, 5)
+                await bot.add_points_to_member(member, -10)
+            else:
+                LOG.info(f"Chore: "
+                    f"\"{member.display_name}\"({member.id}) "
+                    "succeeded to complete the chore")
+                await chore_msg.add_reaction(reward)
+                await bot.add_points_to_member(member, 5)
 
         # This joke always succeeds
         return True


### PR DESCRIPTION
Chores can now be sniped by other users, resulting
in the originally asked to lose points.
Thus they can only be requested by admins now.
Closes #75 